### PR TITLE
feat(availability): replace-on-submit semantics and per-semester admin views

### DIFF
--- a/backend/app/api/availability.py
+++ b/backend/app/api/availability.py
@@ -6,40 +6,115 @@ from app.core.dependencies import require_admin, require_instructor
 from app.models.availability import Availability
 from app.models.instructor import Instructor
 from app.models.user import User
-from app.schemas.availability import AvailabilitySubmit, AvailabilityResponse
+from app.schemas.availability import (
+    AvailabilitySubmit,
+    AvailabilityResponse,
+    AvailabilityBulkSubmit,
+)
 
 router = APIRouter()
+
+ALLOWED_PREFERENCES = {"PREFERRED", "AVAILABLE", "BUSY"}
+
 
 @router.post("/", response_model=list[AvailabilityResponse], status_code=201)
 def submit_availability(
     payload: AvailabilitySubmit,
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_instructor)
+    current_user: User = Depends(require_instructor),
 ):
+    """
+    Legacy single-preference submission.
+    Replaces all rows for (instructor, semester, preference) with the supplied slot_ids.
+    Kept for backward compatibility. New clients should use PUT /availability/.
+    """
     instructor = db.query(Instructor).filter(Instructor.user_id == current_user.id).first()
     if not instructor:
         raise HTTPException(status_code=404, detail="Instructor profile not found")
 
-    db.query(Availability).filter(
-        Availability.instructor_id == instructor.id,
-        Availability.semester == payload.semester,
-        Availability.preference == payload.preference
-    ).delete()
+    try:
+        db.query(Availability).filter(
+            Availability.instructor_id == instructor.id,
+            Availability.semester == payload.semester,
+            Availability.preference == payload.preference,
+        ).delete(synchronize_session=False)
 
-    for slot_id in payload.slot_ids:
-        entry = Availability(
-            instructor_id=instructor.id,
-            slot_id=slot_id,
-            preference=payload.preference,
-            semester=payload.semester
-        )
-        db.add(entry)
+        for slot_id in payload.slot_ids:
+            db.add(Availability(
+                instructor_id=instructor.id,
+                slot_id=slot_id,
+                preference=payload.preference,
+                semester=payload.semester,
+            ))
 
-    db.commit()
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
 
     return db.query(Availability).filter(
         Availability.instructor_id == instructor.id,
-        Availability.semester == payload.semester
+        Availability.semester == payload.semester,
+    ).all()
+
+
+@router.put("/", response_model=list[AvailabilityResponse])
+def replace_availability(
+    payload: AvailabilityBulkSubmit,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_instructor),
+):
+    """
+    Replace-on-submit: atomically clear ALL availability rows for
+    (instructor, semester) and insert the supplied entries.
+
+    This is the correct semantics for "instructor saves their grid":
+    one submission = one source of truth for that semester.
+    """
+    instructor = db.query(Instructor).filter(Instructor.user_id == current_user.id).first()
+    if not instructor:
+        raise HTTPException(status_code=404, detail="Instructor profile not found")
+
+    # Validate preferences before any DB work
+    for entry in payload.entries:
+        if entry.preference not in ALLOWED_PREFERENCES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid preference '{entry.preference}'. Allowed: {sorted(ALLOWED_PREFERENCES)}",
+            )
+
+    # Reject duplicate slot_ids in one submission (would silently overwrite)
+    seen_slots = set()
+    for entry in payload.entries:
+        if entry.slot_id in seen_slots:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Duplicate slot_id {entry.slot_id} in submission",
+            )
+        seen_slots.add(entry.slot_id)
+
+    try:
+        db.query(Availability).filter(
+            Availability.instructor_id == instructor.id,
+            Availability.semester == payload.semester,
+        ).delete(synchronize_session=False)
+
+        for entry in payload.entries:
+            db.add(Availability(
+                instructor_id=instructor.id,
+                slot_id=entry.slot_id,
+                preference=entry.preference,
+                semester=payload.semester,
+            ))
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    return db.query(Availability).filter(
+        Availability.instructor_id == instructor.id,
+        Availability.semester == payload.semester,
     ).all()
 
 
@@ -47,7 +122,7 @@ def submit_availability(
 def get_my_availability(
     semester: Optional[str] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_instructor)
+    current_user: User = Depends(require_instructor),
 ):
     instructor = db.query(Instructor).filter(Instructor.user_id == current_user.id).first()
     if not instructor:
@@ -56,17 +131,26 @@ def get_my_availability(
     query = db.query(Availability).filter(Availability.instructor_id == instructor.id)
     if semester:
         query = query.filter(Availability.semester == semester)
-
     return query.all()
 
 
 @router.get("/{instructor_id}", response_model=List[AvailabilityResponse])
 def get_instructor_availability(
     instructor_id: int,
+    semester: Optional[str] = Query(None),
     db: Session = Depends(get_db),
-    current_user: User = Depends(require_admin)
+    current_user: User = Depends(require_admin),
 ):
+    """
+    Admin view of one instructor's availability.
+    If `semester` is supplied, only rows for that semester are returned.
+    Without it, returns all rows (legacy behavior, kept for any older callers).
+    """
     instructor = db.query(Instructor).filter(Instructor.id == instructor_id).first()
     if not instructor:
         raise HTTPException(status_code=404, detail="Instructor not found")
-    return db.query(Availability).filter(Availability.instructor_id == instructor_id).all()
+
+    query = db.query(Availability).filter(Availability.instructor_id == instructor_id)
+    if semester:
+        query = query.filter(Availability.semester == semester)
+    return query.all()

--- a/backend/app/schemas/availability.py
+++ b/backend/app/schemas/availability.py
@@ -1,10 +1,12 @@
 from pydantic import BaseModel
 from typing import List, Optional
 
+
 class AvailabilitySubmit(BaseModel):
     slot_ids: List[int]
     preference: str
     semester: str
+
 
 class AvailabilityResponse(BaseModel):
     id: int
@@ -16,3 +18,13 @@ class AvailabilityResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class AvailabilitySlotEntry(BaseModel):
+    slot_id: int
+    preference: str  # 'PREFERRED' | 'AVAILABLE' | 'BUSY'
+
+
+class AvailabilityBulkSubmit(BaseModel):
+    semester: str
+    entries: List[AvailabilitySlotEntry]

--- a/frontend/src/components/admin/AvailabilityModal.jsx
+++ b/frontend/src/components/admin/AvailabilityModal.jsx
@@ -18,10 +18,11 @@ const prefConfig = {
   NONE:      { label: 'Not set',   short: '–', color: 'rgba(255,255,255,0.12)', bg: 'rgba(255,255,255,0.02)', border: 'rgba(255,255,255,0.06)' },
 };
 
-export default function AvailabilityModal({ instructor, onClose }) {
+export default function AvailabilityModal({ instructor, semester, onClose }) {
   const { data: availability = [], isLoading } = useQuery({
-    queryKey: ['availability', instructor.id],
-    queryFn: () => api.get(`/availability/${instructor.id}`).then(r => r.data),
+    queryKey: ['availability', instructor.id, semester],
+    queryFn: () => api.get(`/availability/${instructor.id}?semester=${semester}`).then(r => r.data),
+    enabled: !!semester,
   });
 
   const slotMap = Object.fromEntries(

--- a/frontend/src/hooks/useAdminDashboard.js
+++ b/frontend/src/hooks/useAdminDashboard.js
@@ -78,20 +78,20 @@ export function useAdminDashboard() {
   const instructorIdsKey = instructorIds.join(',');
 
   const { data: allAvailability = [] } = useQuery({
-    queryKey: ['all-availability', instructorIdsKey],
+    queryKey: ['all-availability', instructorIdsKey, semester],
     queryFn: async () => {
       const results = await Promise.all(
         instructorIds.map(id =>
-          api.get(`/availability/${id}`)
+          api.get(`/availability/${id}?semester=${semester}`)
             .then(r => ({ instructor_id: id, count: r.data.length }))
             .catch(() => ({ instructor_id: id, count: 0 }))
         )
       );
       return results;
     },
-    enabled: instructorIds.length > 0,
+    enabled: instructorIds.length > 0 && !!semester,
   });
-
+  
   const availabilityMap = Object.fromEntries(
     allAvailability.map(a => [a.instructor_id, a.count > 0])
   );

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -86,6 +86,7 @@ export default function AdminDashboard() {
       {selectedInstructor && (
         <AvailabilityModal
           instructor={selectedInstructor}
+          semester={semester}
           onClose={() => setSelectedInstructor(null)}
         />
       )}

--- a/frontend/src/pages/InstructorPortal.jsx
+++ b/frontend/src/pages/InstructorPortal.jsx
@@ -138,19 +138,10 @@ const { data: instructorProfile, isLoading: profileLoading } = useQuery({
 
   const submitMutation = useMutation({
     mutationFn: async (payload) => {
-      const preferred = payload.filter(s => s.preference === 'PREFERRED').map(s => s.slot_id);
-      const available = payload.filter(s => s.preference === 'AVAILABLE').map(s => s.slot_id);
-      const busy = payload.filter(s => s.preference === 'BUSY').map(s => s.slot_id);
-
-      const calls = [];
-      if (preferred.length) calls.push(api.post('/availability/', { slot_ids: preferred, preference: 'PREFERRED', semester }));
-      if (available.length) calls.push(api.post('/availability/', { slot_ids: available, preference: 'AVAILABLE', semester }));
-      if (busy.length) calls.push(api.post('/availability/', { slot_ids: busy, preference: 'BUSY', semester }));
-      if (!preferred.length) calls.push(api.post('/availability/', { slot_ids: [], preference: 'PREFERRED', semester }));
-      if (!available.length) calls.push(api.post('/availability/', { slot_ids: [], preference: 'AVAILABLE', semester }));
-      if (!busy.length) calls.push(api.post('/availability/', { slot_ids: [], preference: 'BUSY', semester }));
-
-      return Promise.all(calls);
+      // Replace-on-submit: send all entries in one atomic PUT.
+      // Backend deletes all existing rows for (instructor, semester) then inserts these.
+      const entries = payload.map(s => ({ slot_id: s.slot_id, preference: s.preference }));
+      return api.put('/availability/', { semester, entries });
     },
     onSuccess: () => {
       toast.success('Availability saved! Admin can now schedule your classes.');


### PR DESCRIPTION
## Summary
Fixes two related bugs in the instructor availability flow:

1. **Additive submissions** — submitting availability used to insert new rows without clearing the instructor's existing rows for the same semester, causing stale data to accumulate across resubmissions. The frontend made 3 parallel POSTs (one per preference), and the backend only deleted rows scoped to `(instructor, semester, preference)` — leaving any preference-bucket the frontend silently skipped untouched.
2. **Admin view aggregated across semesters** — `GET /availability/{instructor_id}` returned every row across every semester. Result: admins saw e.g. "38 available slots submitted" when the instructor had only selected 4 cells for the current semester.

## Changes

### Backend (`backend/app/api/availability.py`, `backend/app/schemas/availability.py`)
- **New endpoint `PUT /availability/`** — atomic replace-on-submit. Deletes all rows for `(instructor, semester)` then inserts the supplied entries in a single transaction. Validates preferences and rejects duplicate slot_ids. Rolls back on exception.
- **New schemas** `AvailabilitySlotEntry` and `AvailabilityBulkSubmit`.
- **`GET /availability/{instructor_id}`** now accepts an optional `?semester=` query param. Without it, behavior is unchanged (legacy callers safe).
- **Legacy `POST /availability/`** kept for backward compatibility, with added `try/rollback` for transactional safety.

### Frontend
- `InstructorPortal.jsx`: replaced three parallel `api.post` calls with a single `api.put('/availability/', { semester, entries })`.
- `AvailabilityModal.jsx` & `AdminDashboard.jsx`: modal now receives `semester` prop and passes it to the GET. Query key includes semester so React Query refetches when admin switches semesters.
- `useAdminDashboard.js`: the "X / Y instructors have submitted" summary now scopes to the selected semester.

## Testing
- All 80 existing pytest tests pass (no new failures, no test removals).
- Manual smoke test verified:
  - Instructor submits 4 cells → admin sees exactly 4 cells.
  - Instructor changes to 2 different cells → admin sees exactly 2 cells (no residue).
  - Switching admin semester re-fetches and shows correct per-semester data.
  - Phase 3 (lock, carry-forward, generate, conflicts) still works end-to-end.

## Not in this PR (follow-ups)
- Cleanup of legacy `2023-x` and `2024-x` availability rows left over from dev testing. Not data-correctness critical — the new code never reads those — but worth a sweep before defense.
- Pydantic v1-style `class Config` deprecation warnings (project-wide, unrelated).