### PR TITLE
chore(deploy): prep backend and frontend for Railway + Vercel deployment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,22 @@
- 
+﻿# Local development environment variables
+# Copy this file to .env and fill in real values
+# NEVER commit the actual .env file
+
+# Database connection (local Docker Postgres)
+DATABASE_URL=postgresql://schedule_user:schedule_pass@localhost:5432/smart_schedule
+
+# JWT signing key — generate with: python -c "import secrets; print(secrets.token_hex(32))"
+# In production, set this via the host's environment variables (e.g. Railway dashboard)
+SECRET_KEY=change-this-to-a-long-random-string
+
+# JWT settings
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=10080
+
+# Environment: development | production
+ENVIRONMENT=development
+
+# Comma-separated list of allowed CORS origins
+# Local dev: http://localhost:5173
+# Production: add the Vercel frontend URL here
+ALLOWED_ORIGINS=http://localhost:5173

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,0 +1,1 @@
+﻿web: uvicorn app.main:app --host 0.0.0.0 --port $PORT

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,14 +1,21 @@
-from logging.config import fileConfig
+﻿from logging.config import fileConfig
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
 
 from app.core.database import Base
+from app.core.config import settings
 import app.models
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+
+# Override sqlalchemy.url from the application settings so migrations
+# target the same database the app uses. This makes the hardcoded value
+# in alembic.ini a local-dev fallback only; in production (Railway),
+# DATABASE_URL comes from the environment.
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
@@ -18,11 +25,6 @@ if config.config_file_name is not None:
 # add your model's MetaData object here
 # for 'autogenerate' support
 target_metadata = Base.metadata
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
 
 
 def run_migrations_offline() -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+﻿from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.api import scheduling
@@ -10,16 +10,23 @@ from app.api import admin
 from app.api import rooms
 from app.api import sections
 from app.api import courses
-from app.api import subjects 
+from app.api import subjects
 
 app = FastAPI(
     title="Smart Instructor Scheduling System",
     version="1.0.0"
 )
 
+# Parse comma-separated origins from env, stripping whitespace and ignoring blanks
+allowed_origins = [
+    origin.strip()
+    for origin in settings.ALLOWED_ORIGINS.split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.ALLOWED_ORIGINS.split(","),
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -35,7 +42,7 @@ app.include_router(admin.router, prefix="/admin", tags=["admin"])
 app.include_router(rooms.router, prefix="/rooms", tags=["rooms"])
 app.include_router(sections.router, prefix="/sections", tags=["sections"])
 app.include_router(courses.router, prefix="/courses", tags=["courses"])
-app.include_router(subjects.router, prefix="/subjects", tags=["subjects"])  
+app.include_router(subjects.router, prefix="/subjects", tags=["subjects"])
 
 @app.get("/health")
 def health_check():

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,28 +1,10 @@
-// import { defineConfig } from 'vite'
-// import react from '@vitejs/plugin-react'
-
-// // https://vite.dev/config//
-// export default defineConfig({
-//   plugins: [react()],
-  
-// })
-  import { defineConfig } from 'vite'
+﻿import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      }
-    }
-  }
+  },
 })
-
-
-
-


### PR DESCRIPTION
## Summary
   Prepares the backend and frontend for production deployment to Railway (backend + Postgres) and Vercel (frontend). No business logic changes; all 80 pytest tests still pass.

   ## Changes
   ### Backend
   - **`backend/Procfile`** — new file. Tells Railway how to start the app: `uvicorn app.main:app --host 0.0.0.0 --port $PORT`. Binding to `0.0.0.0` is required inside Railway's container; `$PORT` is injected at deploy time.
   - **`backend/.env.example`** — populated with placeholder values documenting every required environment variable. The real `.env` file remains gitignored.
   - **`backend/app/main.py`** — CORS middleware now strips whitespace and filters empty entries when parsing `ALLOWED_ORIGINS`, so a stray space in Railway's env var dashboard won't silently break CORS.
   - **`backend/alembic/env.py`** — overrides `sqlalchemy.url` with `settings.DATABASE_URL` so Alembic uses the same connection string as the app. Previously hardcoded to `localhost` in `alembic.ini`, which would have failed on Railway.

   ### Frontend
   - **`frontend/vite.config.js`** — removed unused dev proxy and commented-out template. The proxy was dead code (verified via grep — no component used the `/api/` prefix).

   ## Testing
   - `pytest tests/ -v` → 80 passed
   - `npm run build` → succeeds, 1898 modules transformed
   - Local backend still runs against Docker Postgres unchanged
   - Local frontend still hits `localhost:8000` via the fallback in `api.js`

   ## Not deployed yet
   This PR only prepares the code. Actual Railway and Vercel setup follows in a separate task.