### PR TITLE
fix(vercel): add SPA fallback rewrite for react-router routes

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
React Router uses client-side routing — URLs like /admin, /instructor, /proposals exist only in JS, not as files on Vercel. Without a rewrite, Vercel returns 404 for any path other than /. The `vercel.json` rewrite rule sends every request to `/`, where index.html loads React, which then reads the URL and renders the matching route.